### PR TITLE
Upgrade choco patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.2
+- upgraded choco from 3.3.0 to 3.3.3
+
 ## 0.3.1
 - added namespace `loco.automata` for creating FiniteAutomaton objects
 - replaced `$regex` with more general-purpose `$regular`

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
  :deps
  {
   org.clojure/clojure {:mvn/version "1.7.0"}
-  org.choco-solver/choco-solver {:mvn/version "3.3.0"}
+  org.choco-solver/choco-solver {:mvn/version "3.3.3"}
   }
 
  :aliases


### PR DESCRIPTION
Just a small thing that I think is worth publishing. Of course consumers could override the dep without issue, but I think it's better to keep up to date with exclusive transitive deps so consumers don't worry and don't forget. 